### PR TITLE
add flag to indicate whether to delete intellectual_rights.txt

### DIFF
--- a/R/edi-utilities.R
+++ b/R/edi-utilities.R
@@ -43,8 +43,8 @@ generate_attribute_tsv <- function(excel_path, columns, output_path) {
 #' the EML assembly line
 #' @export
 excel_to_template <- function(metadata_path, edi_filename, rights,
-                              columns=FALSE, data_table=FALSE, bbox=FALSE,
-                              output_path=FALSE, file_type=".txt") {
+                              columns=FALSE, data_table=FALSE, output_path=FALSE, 
+                              file_type=".txt", del_rights=TRUE) {
 
   excel_path = glue::glue('{metadata_path}.xlsx')
 
@@ -70,8 +70,12 @@ excel_to_template <- function(metadata_path, edi_filename, rights,
   sheet_to_tsv(excel_path, 'CustomUnits', glue::glue(output_path_prefix, 'custom_units.txt'))
   sheet_to_tsv(excel_path, 'Personnel', glue::glue(output_path_prefix, 'personnel.txt'))
 
-  # need to update the rights in this file if they change
-  unlink("intellectual_rights.txt")
+  # set del_rights to TRUE update the rights in this file if they change from CC0 to CCBY or vice versa
+  # set del_rights to FALSE in the case where using a data pkg that has another license and special notes
+  # are supplied
+  if (del_rights) {
+     unlink("intellectual_rights.txt")
+  }
   
   # Import abstract and methods
   EMLassemblyline::template_core_metadata(path = output_path, license = rights, file_type)


### PR DESCRIPTION
fixes issue #17 .

Add del_rights flag, default is TRUE.

To test: In nes-lter-chl-transect, change the call to `excel_to_template` in chl-transect-eml-assembly.Rmd to:
excel_to_template(here(metadata), edi_filename, rights='CC0', _del_rights=FALSE_)

Run the Rmd file and verify that intellectual_rights.txt is not deleted and replaced with a new copy.